### PR TITLE
Remove unnecessary spacebar at section 2.1.3

### DIFF
--- a/versions/1.1/README.md
+++ b/versions/1.1/README.md
@@ -36,7 +36,7 @@ ALI, Restatement of Torts, Third, Product Liability (1998).<sup>[11](#fn11)</sup
 
 #### 2.1.3. Shared Blame
 
-ALI, R estatement of Torts, Third, Apportionment of Liability (2000).<sup>[12](#fn12)</sup>
+ALI, Restatement of Torts, Third, Apportionment of Liability (2000).<sup>[12](#fn12)</sup>
 
 #### 2.1.4. Personal Harm
 


### PR DESCRIPTION
At section 2.1.3, Restatement is written "R estatement", now fixed to "Restatement"