### PR TITLE
Removal of governmental immunity for v. 1.2

### DIFF
--- a/versions/1.1/README.md
+++ b/versions/1.1/README.md
@@ -28,7 +28,7 @@ The losing party pays the winning party's legal costs.<sup>[3](#fn3)</sup>
 
 #### 2.1.1. Generally
 
-ALI, [Restatement of Torts, Second (1965-79)](https://web.archive.org/web/20160430/https://www.ali.org/publications/show/torts/).
+ALI, [Restatement of Torts, Second (1965-79)](https://web.archive.org/web/20160430/https://www.ali.org/publications/show/torts/), excepting §§ 895 A-D (immunizing government agents from liability for their torts).
 
 #### 2.1.2. Defective Products
 


### PR DESCRIPTION
This change nixes rules that might otherwise immunize government actors or, per the operation of Ulex rule 3.2, parties representing "the closest functionally equivalent institution [or] office . . . ."